### PR TITLE
feat: add haptic feedback to UI elements

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
         android:allowBackup="true"

--- a/core/data/src/main/java/me/sanao1006/core/data/util/VibratorUtil.kt
+++ b/core/data/src/main/java/me/sanao1006/core/data/util/VibratorUtil.kt
@@ -1,0 +1,11 @@
+package me.sanao1006.core.data.util
+
+import android.annotation.SuppressLint
+import android.os.VibrationEffect
+import android.os.Vibrator
+
+@SuppressLint("MissingPermission")
+fun Vibrator.vibrate() {
+    cancel()
+    vibrate(VibrationEffect.createPredefined(VibrationEffect.EFFECT_CLICK))
+}

--- a/core/ui/src/main/java/me/sanao1006/core/ui/MainScreenBottomAppBar.kt
+++ b/core/ui/src/main/java/me/sanao1006/core/ui/MainScreenBottomAppBar.kt
@@ -1,5 +1,7 @@
 package me.sanao1006.core.ui
 
+import android.annotation.SuppressLint
+import android.os.Vibrator
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -9,9 +11,12 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.core.content.getSystemService
 import ir.alirezaivaz.tablericons.TablerIcons
+import me.sanao1006.core.data.util.vibrate
 import me.sanao1006.screens.MainScreenType
 import me.sanao1006.screens.event.BottomAppBarActionEvent
 
@@ -30,6 +35,7 @@ fun MainScreenBottomAppBarWrapper(
     floatingActionButton = floatingActionButton
 )
 
+@SuppressLint("MissingPermission")
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun MainScreenBottomAppBar(
@@ -39,13 +45,18 @@ private fun MainScreenBottomAppBar(
     modifier: Modifier = Modifier,
     floatingActionButton: @Composable RowScope.() -> Unit = {}
 ) {
+    val context = LocalContext.current
+    val vibrator = context.getSystemService<Vibrator>()
     HorizontalFloatingAppBar(
         expanded = true,
         modifier = modifier,
         leadingContent = {
             IconButton(
                 modifier = Modifier.padding(start = 8.dp, end = 16.dp),
-                onClick = onHomeClick
+                onClick = {
+                    vibrator?.vibrate()
+                    onHomeClick()
+                }
             ) {
                 Icon(
                     painter = painterResource(
@@ -62,7 +73,10 @@ private fun MainScreenBottomAppBar(
         trailingContent = {
             IconButton(
                 modifier = Modifier.padding(start = 16.dp, end = 8.dp),
-                onClick = onNotificationClick
+                onClick = {
+                    vibrator?.vibrate()
+                    onNotificationClick()
+                }
             ) {
                 Icon(
                     painter = painterResource(

--- a/core/ui/src/main/java/me/sanao1006/core/ui/TimelineComposables.kt
+++ b/core/ui/src/main/java/me/sanao1006/core/ui/TimelineComposables.kt
@@ -1,6 +1,7 @@
 package me.sanao1006.core.ui
 
 import android.content.Context
+import android.os.Vibrator
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -33,9 +34,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import androidx.core.content.getSystemService
 import coil3.compose.AsyncImage
 import ir.alirezaivaz.tablericons.TablerIcons
 import me.sanao1006.core.data.util.getRelativeTimeString
+import me.sanao1006.core.data.util.vibrate
 import me.sanao1006.core.model.common.User
 import me.sanao1006.core.model.notes.TimelineItem
 import me.sanao1006.core.model.notes.Visibility
@@ -57,6 +60,9 @@ fun TimelineColumn(
     onReactionClick: (NoteId) -> Unit,
     onOptionClick: (NoteId, UserId?, Username?, Host?, NoteText, NoteUri) -> Unit
 ) {
+    val context = LocalContext.current
+    val vibrator = context.getSystemService<Vibrator>()
+
     LazyColumn(
         modifier = modifier
     ) {
@@ -65,15 +71,26 @@ fun TimelineColumn(
                 TimelineItemSection(
                     modifier = Modifier,
                     timelineItem = timelineUiState,
-                    onIconClick = onIconClick,
+                    onIconClick = { id, username, host ->
+                        vibrator?.vibrate()
+                        onIconClick(id, username, host)
+                    },
                     onReplyClick = {
                         if (!it.user?.username.isNullOrEmpty()) {
+                            vibrator?.vibrate()
                             onReplyClick(it.id, it.user?.username.orEmpty(), it.user?.host)
                         }
                     },
-                    onRepostClick = { onRepostClick(it.id) },
-                    onReactionClick = { onReactionClick(it.id) },
+                    onRepostClick = {
+                        vibrator?.vibrate()
+                        onRepostClick(it.id)
+                    },
+                    onReactionClick = {
+                        vibrator?.vibrate()
+                        onReactionClick(it.id)
+                    },
                     onOptionClick = {
+                        vibrator?.vibrate()
                         onOptionClick(
                             it.id,
                             it.user?.id,


### PR DESCRIPTION
Added haptic feedback (vibration) when interacting with UI elements such as buttons and list items. This provides a more tactile and responsive user experience.

Specifically, haptic feedback is now triggered when:

- Clicking on the home or notification icons in the bottom app bar.
- Clicking on an icon, reply button, repost button, reaction button, or options button in the timeline.

The `android.permission.VIBRATE` permission has been added to the manifest to enable vibration functionality.