### PR TITLE
feat: implement pagination for timelines

### DIFF
--- a/core/domain/src/main/java/me/sanao1006/core/domain/home/GetNotesTimelineUseCase.kt
+++ b/core/domain/src/main/java/me/sanao1006/core/domain/home/GetNotesTimelineUseCase.kt
@@ -12,25 +12,31 @@ class GetNotesTimelineUseCase @Inject constructor(
     private val notesRepository: NotesRepository,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher
 ) {
-    suspend operator fun invoke(timelineType: TimelineType): List<TimelineItem> {
+    suspend operator fun invoke(
+        timelineType: TimelineType,
+        untilId: String? = null
+    ): List<TimelineItem> {
         return withContext(ioDispatcher) {
             try {
                 val response = when (timelineType) {
                     TimelineType.HOME -> notesRepository.getNotesHomeTimeline(
                         notesTimeLineRequestBody = NotesTimeLineRequestBody(
-                            limit = LIMIT
+                            limit = LIMIT,
+                            untilId = untilId ?: ""
                         )
                     )
 
                     TimelineType.SOCIAL -> notesRepository.getNotesHybridTimeline(
                         notesTimeLineRequestBody = NotesTimeLineRequestBody(
-                            limit = LIMIT
+                            limit = LIMIT,
+                            untilId = untilId ?: ""
                         )
                     )
 
                     TimelineType.GLOBAL -> notesRepository.getNotesGlobalTimeline(
                         notesTimeLineRequestBody = NotesTimeLineRequestBody(
-                            limit = LIMIT
+                            limit = LIMIT,
+                            untilId = untilId ?: ""
                         )
                     )
                 }

--- a/core/model/src/main/java/me/sanao1006/core/model/uistate/HomeScreenUiState.kt
+++ b/core/model/src/main/java/me/sanao1006/core/model/uistate/HomeScreenUiState.kt
@@ -3,7 +3,8 @@ package me.sanao1006.core.model.uistate
 import me.sanao1006.core.model.notes.TimelineItem
 
 data class HomeScreenUiState(
-    var timelineItems: List<TimelineItem?> = listOf()
+    var timelineItems: List<TimelineItem?> = listOf(),
+    var untilId: String = ""
 )
 
 enum class TimelineItemAction {

--- a/core/screens/src/main/java/me/sanao1006/screens/HomeScreen.kt
+++ b/core/screens/src/main/java/me/sanao1006/screens/HomeScreen.kt
@@ -41,6 +41,8 @@ data object HomeScreen : Screen {
             data object OnSocialTimelineClicked : TimelineEvent()
             data object OnGlobalTimelineClicked : TimelineEvent()
         }
+
+        data object OnLoadMoreClicked : TimelineEvent()
     }
 }
 

--- a/core/ui/src/main/java/me/sanao1006/core/ui/TimelineComposables.kt
+++ b/core/ui/src/main/java/me/sanao1006/core/ui/TimelineComposables.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -66,13 +67,15 @@ fun TimelineColumn(
     onReplyClick: (NoteId, Username, Host?) -> Unit,
     onRepostClick: (NoteId) -> Unit,
     onReactionClick: (NoteId) -> Unit,
-    onOptionClick: (NoteId, UserId?, Username?, Host?, NoteText, NoteUri) -> Unit
+    onOptionClick: (NoteId, UserId?, Username?, Host?, NoteText, NoteUri) -> Unit,
+    onLoadMoreClick: () -> Unit
 ) {
     val context = LocalContext.current
     val vibrator = context.getSystemService<Vibrator>()
 
     LazyColumn(
         modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
         state = listState
     ) {
         itemsIndexed(timelineItems) { index, it ->
@@ -111,6 +114,15 @@ fun TimelineColumn(
                     }
                 )
                 HorizontalDivider()
+            }
+        }
+        item {
+            IconButton(onClick = onLoadMoreClick) {
+                Icon(
+                    modifier = Modifier.size(18.dp),
+                    painter = painterResource(TablerIcons.TriangleInvertedFilled),
+                    contentDescription = ""
+                )
             }
         }
     }

--- a/feature/antenna/src/main/java/me/sanao1006/feature/antenna/AntennaListScreen.kt
+++ b/feature/antenna/src/main/java/me/sanao1006/feature/antenna/AntennaListScreen.kt
@@ -80,7 +80,8 @@ fun AntennaListScreen(state: AntennaListScreen.State, modifier: Modifier) {
                                 uri
                             )
                         )
-                    }
+                    },
+                    onLoadMoreClick = {}
                 )
             }
         }

--- a/feature/favorites/src/main/java/me/sanao1006/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/main/java/me/sanao1006/feature/favorites/FavoritesScreen.kt
@@ -80,7 +80,8 @@ fun FavoritesScreen(state: FavoritesScreen.State, modifier: Modifier) {
                                 uri
                             )
                         )
-                    }
+                    },
+                    onLoadMoreClick = {}
                 )
             }
         }

--- a/feature/home/src/main/java/me/sanao1006/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/me/sanao1006/feature/home/HomeScreen.kt
@@ -34,6 +34,7 @@ import me.sanao1006.core.ui.MainScreenDrawerWrapper
 import me.sanao1006.core.ui.MainScreenTimelineContentBox
 import me.sanao1006.core.ui.TimelineColumn
 import me.sanao1006.screens.HomeScreen
+import me.sanao1006.screens.HomeScreen.Event.OnLoadMoreClicked
 import me.sanao1006.screens.MainScreenType
 import me.sanao1006.screens.event.globalIcon.GlobalIconEvent
 import me.sanao1006.screens.event.notecreate.NoteCreateEvent
@@ -217,6 +218,9 @@ private fun TimelineColumn(
                         uri
                     )
                 )
+            },
+            onLoadMoreClick = {
+                state.eventSink(OnLoadMoreClicked)
             }
         )
     }


### PR DESCRIPTION
This commit implements pagination for timelines by adding a "load more" button to the bottom of the timeline.

The following changes were made:

- Added a `onLoadMoreClick` callback to the `TimelineColumn` composable.
- Added an `OnLoadMoreClicked` event to the `HomeScreen.Event` sealed class.
- Updated the `GetNotesTimelineUseCase` to accept an optional `untilId` parameter.
- Updated the `HomeScreenPresenter` to handle the `OnLoadMoreClicked` event by fetching more timeline items and updating the UI state.
- Updated the `HomeScreenUiState` to store the `untilId` of the last loaded timeline item.
- Added a `onLoadMoreClick` parameter to the `TimelineColumn` composable call in the `HomeScreen`, `FavoritesScreen`, and `AntennaListScreen`.