### PR TITLE
feat: disable post button when note text is empty

### DIFF
--- a/feature/home/src/main/java/me/sanao1006/feature/note/NoteScreen.kt
+++ b/feature/home/src/main/java/me/sanao1006/feature/note/NoteScreen.kt
@@ -43,6 +43,7 @@ fun NoteScreenUi(state: NoteScreen.State, modifier: Modifier) {
             Scaffold(
                 topBar = {
                     NoteScreenTopAppBar(
+                        isSubmitEnabled = state.uiState.noteText.isNotBlank(),
                         onBackClicked = { state.eventSink(NoteScreen.Event.OnBackClicked) },
                         onNotePostClicked = {
                             focusManager.clearFocus()

--- a/feature/home/src/main/java/me/sanao1006/feature/note/NoteScreenTopAppBar.kt
+++ b/feature/home/src/main/java/me/sanao1006/feature/note/NoteScreenTopAppBar.kt
@@ -18,6 +18,7 @@ import me.snao1006.res_value.ResString
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NoteScreenTopAppBar(
+    isSubmitEnabled: Boolean,
     modifier: Modifier = Modifier,
     onBackClicked: () -> Unit,
     onNotePostClicked: () -> Unit
@@ -34,6 +35,7 @@ fun NoteScreenTopAppBar(
         },
         actions = {
             FilledTonalButton(
+                enabled = isSubmitEnabled,
                 modifier = Modifier.padding(horizontal = 8.dp),
                 onClick = onNotePostClicked
             ) {


### PR DESCRIPTION
This commit disables the "Post" button in the note screen's top app bar when the note text is empty. It also enables the button when the note text is not blank.