### PR TITLE
improve note screen

### DIFF
--- a/core/domain/src/main/java/me/sanao1006/core/domain/user/GetUserShowUserCase.kt
+++ b/core/domain/src/main/java/me/sanao1006/core/domain/user/GetUserShowUserCase.kt
@@ -23,8 +23,8 @@ class GetUserShowUserCase @Inject constructor(
         usersShowRequestBody: UsersShowRequestBody
     ): UserScreenUiState = withContext(ioDispatcher) {
         try {
-            val response = accountRepository.i()
             if (isFromDrawer) {
+                val response = accountRepository.i()
                 response.toUserScreenUiState()
             } else {
                 val user = usersRepository.getUsersShow(usersShowRequestBody)

--- a/core/model/src/main/java/me/sanao1006/core/model/uistate/NoteScreenUiState.kt
+++ b/core/model/src/main/java/me/sanao1006/core/model/uistate/NoteScreenUiState.kt
@@ -1,5 +1,6 @@
 package me.sanao1006.core.model.uistate
 
+import me.sanao1006.core.model.notes.Instance
 import me.sanao1006.core.model.notes.ReactionAcceptance
 import me.sanao1006.core.model.notes.Visibility
 
@@ -11,7 +12,8 @@ data class NoteScreenUiState(
     val isShowBottomSheet: Boolean = false,
     val noteOptionContent: NoteOptionContent = NoteOptionContent.VISIBILITY,
     val replyId: String? = null,
-    val renoteId: String? = null
+    val renoteId: String? = null,
+    val noteTarget: NoteTargetState? = null
 )
 
 enum class NoteOptionContent {
@@ -19,3 +21,13 @@ enum class NoteOptionContent {
     LOCAL_ONLY,
     REACTION_ACCEPTANCE
 }
+
+// reply or quote
+data class NoteTargetState(
+    val userName: String,
+    val name: String?,
+    val avatarUrl: String?,
+    val instance: Instance?,
+    val text: String,
+    val host: String?
+)

--- a/core/model/src/main/java/me/sanao1006/core/model/uistate/TimelineUiState.kt
+++ b/core/model/src/main/java/me/sanao1006/core/model/uistate/TimelineUiState.kt
@@ -5,7 +5,8 @@ data class TimelineUiState(
     val isFavorite: Boolean = false,
     val showBottomSheet: Boolean = false,
     val timelineAction: TimelineItemAction = TimelineItemAction.Renote,
-    val selectedUserId: String? = null,
+    val selectedNoteId: String? = null,
+    val selectedNoteUserId: String? = null,
     val selectedNoteText: String? = null,
     val selectedNoteLink: String? = null
 )

--- a/core/model/src/main/java/me/sanao1006/core/model/uistate/UserScreenUiState.kt
+++ b/core/model/src/main/java/me/sanao1006/core/model/uistate/UserScreenUiState.kt
@@ -2,6 +2,7 @@ package me.sanao1006.core.model.uistate
 
 import me.sanao1006.core.model.common.Field
 import me.sanao1006.core.model.common.User
+import me.sanao1006.core.model.notes.Instance
 
 sealed interface UserScreenUiState {
     data object Loading : UserScreenUiState
@@ -17,7 +18,8 @@ sealed interface UserScreenUiState {
         val followersCount: Int = 0,
         val description: String? = null,
         val fields: List<Field>? = null,
-        val notesCount: Int = 0
+        val notesCount: Int = 0,
+        val instance: Instance? = null
     ) : UserScreenUiState
 }
 
@@ -31,5 +33,6 @@ fun User.toUserScreenUiState() = UserScreenUiState.Success(
     followersCount = followersCount ?: 0,
     description = description,
     fields = fields,
-    notesCount = notesCount ?: 0
+    notesCount = notesCount ?: 0,
+    instance = instance
 )

--- a/core/screens/src/main/java/me/sanao1006/screens/NoteScreen.kt
+++ b/core/screens/src/main/java/me/sanao1006/screens/NoteScreen.kt
@@ -46,5 +46,7 @@ data class NoteScreen(
 @Parcelize
 data class ReplyObject(
     val id: String,
+    val userId: String,
+    val text: String,
     val user: String
 ) : Parcelable

--- a/core/screens/src/main/java/me/sanao1006/screens/NoteScreen.kt
+++ b/core/screens/src/main/java/me/sanao1006/screens/NoteScreen.kt
@@ -11,8 +11,8 @@ import me.sanao1006.core.model.uistate.NoteScreenUiState
 
 @Parcelize
 data class NoteScreen(
-    val replyObject: ReplyObject? = null,
-    val idForQuote: String? = null
+    val replyTargetObject: NoteTargetObject? = null,
+    val quoteObject: NoteTargetObject? = null
 ) : Screen {
     data class State(
         val uiState: NoteScreenUiState,
@@ -44,7 +44,7 @@ data class NoteScreen(
 }
 
 @Parcelize
-data class ReplyObject(
+data class NoteTargetObject(
     val id: String,
     val userId: String,
     val text: String,

--- a/core/screens/src/main/java/me/sanao1006/screens/event/timeline/TimelineEventPresenter.kt
+++ b/core/screens/src/main/java/me/sanao1006/screens/event/timeline/TimelineEventPresenter.kt
@@ -24,6 +24,7 @@ import me.sanao1006.core.model.uistate.TimelineItemAction
 import me.sanao1006.core.model.uistate.TimelineUiState
 import me.sanao1006.datastore.DataStoreRepository
 import me.sanao1006.screens.NoteScreen
+import me.sanao1006.screens.NoteTargetObject
 
 data class TimelineState(
     var uiState: TimelineUiState,
@@ -63,7 +64,9 @@ class TimelineEventPresenter @Inject constructor(
                         uiState.copy(
                             showBottomSheet = true,
                             timelineAction = TimelineItemAction.Renote,
-                            selectedUserId = event.id
+                            selectedNoteId = event.id,
+                            selectedNoteUserId = event.userId,
+                            selectedNoteText = event.text
                         )
                 }
 
@@ -74,7 +77,7 @@ class TimelineEventPresenter @Inject constructor(
                         uiState = uiState.copy(
                             showBottomSheet = true,
                             timelineAction = TimelineItemAction.Option,
-                            selectedUserId = event.id,
+                            selectedNoteId = event.id,
                             selectedNoteText = event.text,
                             selectedNoteLink = event.uri
                         )
@@ -99,7 +102,16 @@ class TimelineEventPresenter @Inject constructor(
 
                 is TimelineItemEvent.OnQuoteClicked -> {
                     uiState = uiState.copy(showBottomSheet = false)
-                    navigator.goTo(NoteScreen(idForQuote = event.id))
+                    navigator.goTo(
+                        NoteScreen(
+                            quoteObject = NoteTargetObject(
+                                id = event.id,
+                                userId = event.userId,
+                                text = event.text,
+                                user = ""
+                            )
+                        )
+                    )
                 }
 
                 is TimelineItemEvent.OnDetailClicked -> {

--- a/core/screens/src/main/java/me/sanao1006/screens/event/timeline/TimelineItemEvent.kt
+++ b/core/screens/src/main/java/me/sanao1006/screens/event/timeline/TimelineItemEvent.kt
@@ -19,6 +19,8 @@ sealed class TimelineItemEvent : CircuitUiEvent {
     data class OnTimelineItemReplyClicked(
         val id: String,
         val user: String,
+        val userId: String?,
+        val text: String,
         val host: String?
     ) : TimelineItemEvent()
 
@@ -92,7 +94,9 @@ fun TimelineItemEvent.OnTimelineItemReplyClicked.handleTimelineItemReplyClicked(
         NoteScreen(
             replyObject = ReplyObject(
                 id = this.id,
-                user = user
+                user = user,
+                text = this.text,
+                userId = this.userId ?: ""
             )
         )
     )

--- a/core/screens/src/main/java/me/sanao1006/screens/event/timeline/TimelineItemEvent.kt
+++ b/core/screens/src/main/java/me/sanao1006/screens/event/timeline/TimelineItemEvent.kt
@@ -5,7 +5,7 @@ import androidx.compose.material3.SnackbarHostState
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.GoToNavigator
 import me.sanao1006.screens.NoteScreen
-import me.sanao1006.screens.ReplyObject
+import me.sanao1006.screens.NoteTargetObject
 import me.sanao1006.screens.UserScreen
 import me.snao1006.res_value.ResString
 
@@ -24,7 +24,12 @@ sealed class TimelineItemEvent : CircuitUiEvent {
         val host: String?
     ) : TimelineItemEvent()
 
-    data class OnTimelineItemRepostClicked(val id: String) : TimelineItemEvent()
+    data class OnTimelineItemRepostClicked(
+        val id: String,
+        val userId: String,
+        val text: String
+    ) : TimelineItemEvent()
+
     data class OnTimelineItemReactionClicked(val id: String) : TimelineItemEvent()
     data class OnTimelineItemOptionClicked(
         val id: String,
@@ -40,7 +45,9 @@ sealed class TimelineItemEvent : CircuitUiEvent {
     ) : TimelineItemEvent()
 
     data class OnQuoteClicked(
-        val id: String
+        val id: String,
+        val userId: String,
+        val text: String
     ) : TimelineItemEvent()
 
     data class OnDetailClicked(
@@ -92,7 +99,7 @@ fun TimelineItemEvent.OnTimelineItemReplyClicked.handleTimelineItemReplyClicked(
     }
     navigator.goTo(
         NoteScreen(
-            replyObject = ReplyObject(
+            replyTargetObject = NoteTargetObject(
                 id = this.id,
                 user = user,
                 text = this.text,

--- a/core/ui/src/main/java/me/sanao1006/core/ui/MainScreenTimelineContentBox.kt
+++ b/core/ui/src/main/java/me/sanao1006/core/ui/MainScreenTimelineContentBox.kt
@@ -40,9 +40,9 @@ fun MainScreenTimelineContentBox(
                 state.timelineEventSink(
                     TimelineItemEvent.OnRenoteClicked(
                         when (state) {
-                            is HomeScreen.State -> state.timelineUiState.selectedUserId ?: ""
+                            is HomeScreen.State -> state.timelineUiState.selectedNoteId ?: ""
                             is NotificationScreen.State ->
-                                state.timelineUiState.selectedUserId
+                                state.timelineUiState.selectedNoteId
                                     ?: ""
 
                             else -> ""
@@ -55,13 +55,17 @@ fun MainScreenTimelineContentBox(
                 when (state) {
                     is HomeScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnQuoteClicked(
-                            state.timelineUiState.selectedUserId ?: ""
+                            id = state.timelineUiState.selectedNoteId ?: "",
+                            userId = state.timelineUiState.selectedNoteUserId ?: "",
+                            text = state.timelineUiState.selectedNoteText ?: ""
                         )
                     )
 
                     is NotificationScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnQuoteClicked(
-                            state.timelineUiState.selectedUserId ?: ""
+                            id = state.timelineUiState.selectedNoteId ?: "",
+                            userId = state.timelineUiState.selectedNoteUserId ?: "",
+                            text = state.timelineUiState.selectedNoteText ?: ""
                         )
                     )
                 }
@@ -74,7 +78,7 @@ fun MainScreenTimelineContentBox(
                 when (state) {
                     is HomeScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnDetailClicked(
-                            state.timelineUiState.selectedUserId ?: "",
+                            state.timelineUiState.selectedNoteId ?: "",
                             null,
                             null
                         )
@@ -82,7 +86,7 @@ fun MainScreenTimelineContentBox(
 
                     is NotificationScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnDetailClicked(
-                            state.timelineUiState.selectedUserId ?: "",
+                            state.timelineUiState.selectedNoteId ?: "",
                             null,
                             null
                         )
@@ -110,14 +114,14 @@ fun MainScreenTimelineContentBox(
                 when (state) {
                     is HomeScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnCopyLinkClicked(
-                            id = state.timelineUiState.selectedUserId ?: "",
+                            id = state.timelineUiState.selectedNoteId ?: "",
                             link = state.timelineUiState.selectedNoteLink ?: ""
                         )
                     )
 
                     is NotificationScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnCopyLinkClicked(
-                            id = state.timelineUiState.selectedUserId ?: "",
+                            id = state.timelineUiState.selectedNoteId ?: "",
                             link = state.timelineUiState.selectedNoteLink ?: ""
                         )
                     )
@@ -128,14 +132,14 @@ fun MainScreenTimelineContentBox(
                 when (state) {
                     is HomeScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnShareClicked(
-                            id = state.timelineUiState.selectedUserId ?: "",
+                            id = state.timelineUiState.selectedNoteId ?: "",
                             link = state.timelineUiState.selectedNoteLink ?: ""
                         )
                     )
 
                     is NotificationScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnShareClicked(
-                            id = state.timelineUiState.selectedUserId ?: "",
+                            id = state.timelineUiState.selectedNoteId ?: "",
                             link = state.timelineUiState.selectedNoteLink ?: ""
                         )
                     )
@@ -146,14 +150,14 @@ fun MainScreenTimelineContentBox(
                 when (state) {
                     is HomeScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnFavoriteClicked(
-                            state.timelineUiState.selectedUserId ?: "",
+                            state.timelineUiState.selectedNoteId ?: "",
                             snackbarHostState
                         )
                     )
 
                     is NotificationScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnFavoriteClicked(
-                            state.timelineUiState.selectedUserId ?: "",
+                            state.timelineUiState.selectedNoteId ?: "",
                             snackbarHostState
                         )
                     )
@@ -252,11 +256,11 @@ fun SubScreenTimelineContentBox(
                     TimelineItemEvent.OnRenoteClicked(
                         when (state) {
                             is FavoritesScreen.State ->
-                                state.timelineUiState.selectedUserId
+                                state.timelineUiState.selectedNoteId
                                     ?: ""
 
                             is AntennaListScreen.State ->
-                                state.timelineUiState.selectedUserId
+                                state.timelineUiState.selectedNoteId
                                     ?: ""
 
                             else -> ""
@@ -269,13 +273,17 @@ fun SubScreenTimelineContentBox(
                 when (state) {
                     is FavoritesScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnQuoteClicked(
-                            state.timelineUiState.selectedUserId ?: ""
+                            id = state.timelineUiState.selectedNoteId ?: "",
+                            userId = state.timelineUiState.selectedNoteUserId ?: "",
+                            text = state.timelineUiState.selectedNoteText ?: ""
                         )
                     )
 
                     is AntennaListScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnQuoteClicked(
-                            state.timelineUiState.selectedUserId ?: ""
+                            id = state.timelineUiState.selectedNoteId ?: "",
+                            userId = state.timelineUiState.selectedNoteUserId ?: "",
+                            text = state.timelineUiState.selectedNoteText ?: ""
                         )
                     )
                 }
@@ -288,7 +296,7 @@ fun SubScreenTimelineContentBox(
                 when (state) {
                     is FavoritesScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnDetailClicked(
-                            state.timelineUiState.selectedUserId ?: "",
+                            state.timelineUiState.selectedNoteId ?: "",
                             null,
                             null
                         )
@@ -296,7 +304,7 @@ fun SubScreenTimelineContentBox(
 
                     is AntennaListScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnDetailClicked(
-                            state.timelineUiState.selectedUserId ?: "",
+                            state.timelineUiState.selectedNoteId ?: "",
                             null,
                             null
                         )
@@ -324,14 +332,14 @@ fun SubScreenTimelineContentBox(
                 when (state) {
                     is FavoritesScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnCopyLinkClicked(
-                            id = state.timelineUiState.selectedUserId ?: "",
+                            id = state.timelineUiState.selectedNoteId ?: "",
                             link = state.timelineUiState.selectedNoteLink ?: ""
                         )
                     )
 
                     is AntennaListScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnCopyLinkClicked(
-                            id = state.timelineUiState.selectedUserId ?: "",
+                            id = state.timelineUiState.selectedNoteId ?: "",
                             link = state.timelineUiState.selectedNoteLink ?: ""
                         )
                     )
@@ -342,7 +350,7 @@ fun SubScreenTimelineContentBox(
                 when (state) {
                     is FavoritesScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnShareClicked(
-                            id = state.timelineUiState.selectedUserId ?: "",
+                            id = state.timelineUiState.selectedNoteId ?: "",
                             link = state.timelineUiState.selectedNoteLink ?: ""
                         )
                     )
@@ -350,7 +358,7 @@ fun SubScreenTimelineContentBox(
                     is AntennaListScreen.State -> {
                         state.timelineEventSink(
                             TimelineItemEvent.OnShareClicked(
-                                id = state.timelineUiState.selectedUserId ?: "",
+                                id = state.timelineUiState.selectedNoteId ?: "",
                                 link = state.timelineUiState.selectedNoteLink ?: ""
                             )
                         )
@@ -362,14 +370,14 @@ fun SubScreenTimelineContentBox(
                 when (state) {
                     is FavoritesScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnFavoriteClicked(
-                            state.timelineUiState.selectedUserId ?: "",
+                            state.timelineUiState.selectedNoteId ?: "",
                             snackbarHostState
                         )
                     )
 
                     is AntennaListScreen.State -> state.timelineEventSink(
                         TimelineItemEvent.OnFavoriteClicked(
-                            state.timelineUiState.selectedUserId ?: "",
+                            state.timelineUiState.selectedNoteId ?: "",
                             snackbarHostState
                         )
                     )

--- a/core/ui/src/main/java/me/sanao1006/core/ui/TimelineComposables.kt
+++ b/core/ui/src/main/java/me/sanao1006/core/ui/TimelineComposables.kt
@@ -73,7 +73,7 @@ fun TimelineColumn(
     timelineItems: List<TimelineItem?>,
     onIconClick: (String, String?, String?) -> Unit,
     onReplyClick: (NoteId, Username, UserId?, NoteText, Host?) -> Unit,
-    onRepostClick: (NoteId) -> Unit,
+    onRepostClick: (NoteId, UserId, NoteText) -> Unit,
     onReactionClick: (NoteId) -> Unit,
     onOptionClick: (NoteId, UserId?, Username?, Host?, NoteText, NoteUri) -> Unit
 ) {
@@ -160,7 +160,7 @@ fun TimelineColumn(
                         },
                         onRepostClick = {
                             vibrator?.vibrate()
-                            onRepostClick(it.id)
+                            onRepostClick(it.id, it.user?.id.orEmpty(), it.text)
                         },
                         onReactionClick = {
                             vibrator?.vibrate()

--- a/core/ui/src/main/java/me/sanao1006/core/ui/TimelineComposables.kt
+++ b/core/ui/src/main/java/me/sanao1006/core/ui/TimelineComposables.kt
@@ -72,7 +72,7 @@ fun TimelineColumn(
     modifier: Modifier = Modifier,
     timelineItems: List<TimelineItem?>,
     onIconClick: (String, String?, String?) -> Unit,
-    onReplyClick: (NoteId, Username, Host?) -> Unit,
+    onReplyClick: (NoteId, Username, UserId?, NoteText, Host?) -> Unit,
     onRepostClick: (NoteId) -> Unit,
     onReactionClick: (NoteId) -> Unit,
     onOptionClick: (NoteId, UserId?, Username?, Host?, NoteText, NoteUri) -> Unit
@@ -149,7 +149,13 @@ fun TimelineColumn(
                         onReplyClick = {
                             if (!it.user?.username.isNullOrEmpty()) {
                                 vibrator?.vibrate()
-                                onReplyClick(it.id, it.user?.username.orEmpty(), it.user?.host)
+                                onReplyClick(
+                                    it.id,
+                                    it.user?.username.orEmpty(),
+                                    it.user?.id,
+                                    it.text,
+                                    it.user?.host
+                                )
                             }
                         },
                         onRepostClick = {
@@ -227,7 +233,8 @@ fun TimelineItemSection(
                         modifier = Modifier.fillMaxWidth()
                     ) {
                         val instanceName = timelineItem.user?.host
-                        val name = "@${timelineItem.user?.username}${instanceName?.let {
+                        val name = "@${timelineItem.user?.username}${
+                        instanceName?.let {
                             "@$it"
                         } ?: ""
                         }"
@@ -311,7 +318,7 @@ private fun ReplySection(
         leadingContent = {
             AsyncImage(
                 modifier = Modifier
-                    .size(48.dp)
+                    .size(40.dp)
                     .clip(shape = CircleShape)
                     .clickable {
                         onIconClick(

--- a/feature/antenna/src/main/java/me/sanao1006/feature/antenna/AntennaListScreen.kt
+++ b/feature/antenna/src/main/java/me/sanao1006/feature/antenna/AntennaListScreen.kt
@@ -61,10 +61,12 @@ fun AntennaListScreen(state: AntennaListScreen.State, modifier: Modifier) {
                             )
                         )
                     },
-                    onRepostClick = { userId ->
+                    onRepostClick = { noteId, userId, text ->
                         state.timelineEventSink(
                             TimelineItemEvent.OnTimelineItemRepostClicked(
-                                userId
+                                noteId,
+                                userId,
+                                text
                             )
                         )
                     },

--- a/feature/antenna/src/main/java/me/sanao1006/feature/antenna/AntennaListScreen.kt
+++ b/feature/antenna/src/main/java/me/sanao1006/feature/antenna/AntennaListScreen.kt
@@ -50,9 +50,15 @@ fun AntennaListScreen(state: AntennaListScreen.State, modifier: Modifier) {
                             )
                         )
                     },
-                    onReplyClick = { id, user, host ->
+                    onReplyClick = { id, user, userId, text, host ->
                         state.timelineEventSink(
-                            TimelineItemEvent.OnTimelineItemReplyClicked(id, user, host)
+                            TimelineItemEvent.OnTimelineItemReplyClicked(
+                                id,
+                                user,
+                                userId,
+                                text,
+                                host
+                            )
                         )
                     },
                     onRepostClick = { userId ->

--- a/feature/favorites/src/main/java/me/sanao1006/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/main/java/me/sanao1006/feature/favorites/FavoritesScreen.kt
@@ -50,9 +50,15 @@ fun FavoritesScreen(state: FavoritesScreen.State, modifier: Modifier) {
                             )
                         )
                     },
-                    onReplyClick = { id, user, host ->
+                    onReplyClick = { id, user, userId, text, host ->
                         state.timelineEventSink(
-                            TimelineItemEvent.OnTimelineItemReplyClicked(id, user, host)
+                            TimelineItemEvent.OnTimelineItemReplyClicked(
+                                id,
+                                user,
+                                userId,
+                                text,
+                                host
+                            )
                         )
                     },
                     onRepostClick = { userId ->

--- a/feature/favorites/src/main/java/me/sanao1006/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/main/java/me/sanao1006/feature/favorites/FavoritesScreen.kt
@@ -61,10 +61,12 @@ fun FavoritesScreen(state: FavoritesScreen.State, modifier: Modifier) {
                             )
                         )
                     },
-                    onRepostClick = { userId ->
+                    onRepostClick = { noteId, userId, text ->
                         state.timelineEventSink(
                             TimelineItemEvent.OnTimelineItemRepostClicked(
-                                userId
+                                noteId,
+                                userId,
+                                text
                             )
                         )
                     },

--- a/feature/home/src/main/java/me/sanao1006/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/me/sanao1006/feature/home/HomeScreen.kt
@@ -191,10 +191,12 @@ private fun TimelineColumn(
                     TimelineItemEvent.OnTimelineItemReplyClicked(id, user, userId, noteText, host)
                 )
             },
-            onRepostClick = { userId ->
+            onRepostClick = { noteId, userId, text ->
                 state.timelineEventSink(
                     TimelineItemEvent.OnTimelineItemRepostClicked(
-                        userId
+                        noteId,
+                        userId,
+                        text
                     )
                 )
             },

--- a/feature/home/src/main/java/me/sanao1006/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/me/sanao1006/feature/home/HomeScreen.kt
@@ -186,9 +186,9 @@ private fun TimelineColumn(
                     )
                 )
             },
-            onReplyClick = { id, user, host ->
+            onReplyClick = { id, user, userId, noteText, host ->
                 state.timelineEventSink(
-                    TimelineItemEvent.OnTimelineItemReplyClicked(id, user, host)
+                    TimelineItemEvent.OnTimelineItemReplyClicked(id, user, userId, noteText, host)
                 )
             },
             onRepostClick = { userId ->

--- a/feature/home/src/main/java/me/sanao1006/feature/note/NoteScreen.kt
+++ b/feature/home/src/main/java/me/sanao1006/feature/note/NoteScreen.kt
@@ -5,7 +5,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -13,17 +17,24 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.retained.rememberRetained
 import com.slack.circuitx.effects.LaunchedImpressionEffect
 import dagger.hilt.components.SingletonComponent
 import me.sanao1006.core.designsystem.MintTheme
 import me.sanao1006.core.model.uistate.NoteOptionContent
+import me.sanao1006.core.model.uistate.NoteTargetState
 import me.sanao1006.screens.NoteScreen
 import me.snao1006.res_value.ResString
 
@@ -76,6 +87,11 @@ private fun NoteScreenContent(
     Column(
         modifier = modifier
     ) {
+        // reply or quote target
+        state.uiState.noteTarget?.let {
+            ReplyTargetNote(it)
+        }
+
         NoteScreenTextField(
             modifier = Modifier
                 .fillMaxSize()
@@ -122,6 +138,40 @@ private fun NoteScreenTextField(
             )
         }
     )
+}
+
+@Composable
+private fun ReplyTargetNote(noteTargetState: NoteTargetState) {
+    ElevatedCard {
+        ListItem(
+            leadingContent = {
+                AsyncImage(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(shape = CircleShape),
+                    model = noteTargetState.avatarUrl,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop
+                )
+            },
+            headlineContent = {
+                Text(
+                    text = noteTargetState.name ?: noteTargetState.userName,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            },
+            supportingContent = {
+                Text(
+                    text = noteTargetState.text,
+                    maxLines = 5,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/feature/home/src/main/java/me/sanao1006/feature/note/NoteScreenPresenter.kt
+++ b/feature/home/src/main/java/me/sanao1006/feature/note/NoteScreenPresenter.kt
@@ -34,14 +34,40 @@ class NoteScreenPresenter @AssistedInject constructor(
         var uiState by rememberRetained {
             mutableStateOf(
                 NoteScreenUiState(
-                    noteText = screen.replyObject?.user ?: "",
-                    replyId = screen.replyObject?.id,
-                    renoteId = screen.idForQuote
+                    noteText = screen.replyTargetObject?.user ?: "",
+                    replyId = screen.replyTargetObject?.id,
+                    renoteId = screen.quoteObject?.id
                 )
             )
         }
 
-        screen.replyObject?.let {
+        screen.replyTargetObject?.let {
+            LaunchedImpressionEffect(Unit) {
+                val user = getUserShowUserCase
+                    .invoke(
+                        isFromDrawer = false,
+                        usersShowRequestBody = UsersShowRequestBody(userId = it.userId)
+                    )
+                when (user) {
+                    is UserScreenUiState.Success -> {
+                        uiState = uiState.copy(
+                            noteTarget = NoteTargetState(
+                                userName = user.username,
+                                name = user.name,
+                                avatarUrl = user.avatarUrl,
+                                instance = user.instance,
+                                text = it.text,
+                                host = user.host
+                            )
+                        )
+                    }
+
+                    else -> {}
+                }
+            }
+        }
+
+        screen.quoteObject?.let {
             LaunchedImpressionEffect(Unit) {
                 val user = getUserShowUserCase
                     .invoke(

--- a/feature/notification/src/main/java/me/sanao1006/feature/notification/NotificationComposables.kt
+++ b/feature/notification/src/main/java/me/sanao1006/feature/notification/NotificationComposables.kt
@@ -62,7 +62,7 @@ fun NotificationColumn(
     context: Context,
     notifications: List<NotificationUiStateObject>,
     onIconClick: (String, String?, String?) -> Unit,
-    onReplyClick: (NoteId, Username, Host?) -> Unit,
+    onReplyClick: (NoteId, Username, UserId, NoteText, Host?) -> Unit,
     onRepostClick: (NoteId) -> Unit,
     onReactionClick: (NoteId) -> Unit,
     onOptionClick: (NoteId, UserId?, Username?, Host?, NoteText, NoteUri) -> Unit
@@ -112,7 +112,7 @@ private fun NotificationSectionMessage(
     notificationUiState: NotificationUiStateObject,
     modifier: Modifier = Modifier,
     onIconClick: (String, String?, String?) -> Unit,
-    onReplyClick: (NoteId, Username, Host?) -> Unit,
+    onReplyClick: (NoteId, Username, UserId, NoteText, Host?) -> Unit,
     onRepostClick: (NoteId) -> Unit,
     onReactionClick: (NoteId) -> Unit,
     onOptionClick: (NoteId, UserId?, Username?, Host?, NoteText, NoteUri) -> Unit
@@ -156,6 +156,8 @@ private fun NotificationSectionMessage(
                         onReplyClick(
                             notificationUiState.timelineItem!!.id,
                             notificationUiState.timelineItem!!.user!!.username,
+                            notificationUiState.timelineItem!!.user!!.id,
+                            notificationUiState.timelineItem!!.text,
                             notificationUiState.user?.host
                         )
                     }
@@ -475,7 +477,7 @@ private fun PreviewNotificationColumn() {
                 context = context,
                 notifications = notifications,
                 onIconClick = { _, _, _ -> },
-                onReplyClick = { _, _, _ -> },
+                onReplyClick = { _, _, _, _, _ -> },
                 onRepostClick = {},
                 onOptionClick = { _, _, _, _, _, _ -> },
                 onReactionClick = {}

--- a/feature/notification/src/main/java/me/sanao1006/feature/notification/NotificationComposables.kt
+++ b/feature/notification/src/main/java/me/sanao1006/feature/notification/NotificationComposables.kt
@@ -63,7 +63,7 @@ fun NotificationColumn(
     notifications: List<NotificationUiStateObject>,
     onIconClick: (String, String?, String?) -> Unit,
     onReplyClick: (NoteId, Username, UserId, NoteText, Host?) -> Unit,
-    onRepostClick: (NoteId) -> Unit,
+    onRepostClick: (NoteId, UserId, NoteText) -> Unit,
     onReactionClick: (NoteId) -> Unit,
     onOptionClick: (NoteId, UserId?, Username?, Host?, NoteText, NoteUri) -> Unit
 ) {
@@ -113,7 +113,7 @@ private fun NotificationSectionMessage(
     modifier: Modifier = Modifier,
     onIconClick: (String, String?, String?) -> Unit,
     onReplyClick: (NoteId, Username, UserId, NoteText, Host?) -> Unit,
-    onRepostClick: (NoteId) -> Unit,
+    onRepostClick: (NoteId, UserId, NoteText) -> Unit,
     onReactionClick: (NoteId) -> Unit,
     onOptionClick: (NoteId, UserId?, Username?, Host?, NoteText, NoteUri) -> Unit
 ) {
@@ -162,7 +162,13 @@ private fun NotificationSectionMessage(
                         )
                     }
                 },
-                onRepostClick = { onRepostClick(notificationUiState.id) },
+                onRepostClick = {
+                    onRepostClick(
+                        notificationUiState.id,
+                        notificationUiState.user?.id.orEmpty(),
+                        notificationUiState.timelineItem!!.text
+                    )
+                },
                 onReactionClick = { onReactionClick(notificationUiState.id) },
                 onOptionClick = {
                     onOptionClick(
@@ -478,7 +484,7 @@ private fun PreviewNotificationColumn() {
                 notifications = notifications,
                 onIconClick = { _, _, _ -> },
                 onReplyClick = { _, _, _, _, _ -> },
-                onRepostClick = {},
+                onRepostClick = { _, _, _ -> },
                 onOptionClick = { _, _, _, _, _, _ -> },
                 onReactionClick = {}
             )

--- a/feature/notification/src/main/java/me/sanao1006/feature/notification/NotificationScreen.kt
+++ b/feature/notification/src/main/java/me/sanao1006/feature/notification/NotificationScreen.kt
@@ -156,10 +156,12 @@ private fun NotificationScreenContent(
                         TimelineItemEvent.OnTimelineItemReplyClicked(id, user, userId, text, host)
                     )
                 },
-                onRepostClick = { userId ->
+                onRepostClick = { noteId, userId, text ->
                     state.timelineEventSink(
                         TimelineItemEvent.OnTimelineItemRepostClicked(
-                            userId
+                            id = noteId,
+                            userId = userId,
+                            text = text
                         )
                     )
                 },

--- a/feature/notification/src/main/java/me/sanao1006/feature/notification/NotificationScreen.kt
+++ b/feature/notification/src/main/java/me/sanao1006/feature/notification/NotificationScreen.kt
@@ -151,9 +151,9 @@ private fun NotificationScreenContent(
                         )
                     )
                 },
-                onReplyClick = { id, user, host ->
+                onReplyClick = { id, user, userId, text, host ->
                     state.timelineEventSink(
-                        TimelineItemEvent.OnTimelineItemReplyClicked(id, user, host)
+                        TimelineItemEvent.OnTimelineItemReplyClicked(id, user, userId, text, host)
                     )
                 },
                 onRepostClick = { userId ->


### PR DESCRIPTION
- Add `reply` parameter to `TimelineItemEvent.OnTimelineItemReplyClicked` for passing reply details.
- Update `NotificationComposables` and `TimelineComposables` to handle `userId` and `text` when a reply is clicked.
- Modify `NoteScreenPresenter` to fetch the user information for the note being replied to and update the UI state.
- Implement `ReplyTargetNote` composable in `NoteScreen` to display the note being replied to.
- Update `GetUserShowUserCase` to handle the case where the user is not from drawer.
- Update `UserScreenUiState` to support `instance`.