### PR TITLE
fix: update instance model to use nullable types

### DIFF
--- a/core/model/src/main/java/me/sanao1006/core/model/notes/Instance.kt
+++ b/core/model/src/main/java/me/sanao1006/core/model/notes/Instance.kt
@@ -6,15 +6,15 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Instance(
     @SerialName("faviconUrl")
-    val faviconUrl: String = "",
+    val faviconUrl: String? = null,
     @SerialName("iconUrl")
-    val iconUrl: String = "",
+    val iconUrl: String? = null,
     @SerialName("name")
-    val name: String = "",
+    val name: String? = null,
     @SerialName("softwareName")
-    val softwareName: String = "",
+    val softwareName: String? = null,
     @SerialName("softwareVersion")
-    val softwareVersion: String = "",
+    val softwareVersion: String? = null,
     @SerialName("themeColor")
-    val themeColor: String = ""
+    val themeColor: String? = null
 )


### PR DESCRIPTION
The Instance data class was updated to use nullable types for its properties: `faviconUrl`, `iconUrl`, `name`, `softwareName`, `softwareVersion`, and `themeColor`. This change allows these fields to be null, in addition to strings.