### PR TITLE
change: URL pattern for linkify text

### DIFF
--- a/core/data/src/main/java/me/sanao1006/core/data/util/LinkifyText.kt
+++ b/core/data/src/main/java/me/sanao1006/core/data/util/LinkifyText.kt
@@ -1,6 +1,5 @@
 package me.sanao1006.core.data.util
 
-import android.util.Patterns
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,6 +16,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.TextUnit
+import java.util.regex.Pattern
 
 @Composable
 fun LinkifyText(
@@ -78,8 +78,15 @@ private data class LinkInfo(
     val end: Int
 )
 
+private val urlPattern: Pattern = Pattern.compile(
+    "(?:^|[\\W])((ht|f)tp(s?):\\/\\/|www\\.)" +
+        "(([\\w\\-]+\\.){1,}?([\\w\\-.~]+\\/?)*" +
+        "[\\p{Alnum}.,%_=?&#\\-+()\\[\\]\\*$~@!:/{};']*)",
+    Pattern.CASE_INSENSITIVE or Pattern.MULTILINE or Pattern.DOTALL
+)
+
 private fun extractUrls(text: String): List<LinkInfo> = buildList {
-    val matcher = Patterns.WEB_URL.matcher(text)
+    val matcher = urlPattern.matcher(text)
     while (matcher.find()) {
         val matchStart = matcher.start(1)
         val matchEnd = matcher.end()


### PR DESCRIPTION
This commit introduces a new URL pattern for linkifying text. The `urlPattern` variable now uses a more comprehensive regular expression to identify URLs, improving the accuracy of link detection. The `Patterns.WEB_URL` has been replaced by custom URL pattern.