### PR TITLE
Use Patterns for URI validation

### DIFF
--- a/feature/login/src/main/java/me/sanao1006/feature/login/LoginScreenPresenter.kt
+++ b/feature/login/src/main/java/me/sanao1006/feature/login/LoginScreenPresenter.kt
@@ -20,6 +20,8 @@ import de.jensklingenberg.ktorfit.Ktorfit
 import de.jensklingenberg.ktorfit.converter.FlowConverterFactory
 import de.jensklingenberg.ktorfit.converter.ResponseConverterFactory
 import io.ktor.client.HttpClient
+import java.security.MessageDigest
+import javax.inject.Inject
 import kotlinx.coroutines.launch
 import me.sanao1006.core.data.repository.createMiauthRepository
 import me.sanao1006.core.data.util.suspendRunCatching
@@ -33,8 +35,6 @@ import me.sanao1006.datastore.DataStoreRepository
 import me.sanao1006.screens.AuthStateType
 import me.sanao1006.screens.LoginScreen
 import me.snao1006.res_value.ResString
-import java.security.MessageDigest
-import javax.inject.Inject
 
 @CircuitInject(LoginScreen::class, SingletonComponent::class)
 class LoginScreenPresenter @Inject constructor(
@@ -68,7 +68,7 @@ class LoginScreenPresenter @Inject constructor(
             when (event) {
                 is LoginScreen.Event.OnTextChanged -> {
                     buttonEnabled = event.text.isNotBlank() &&
-                            Patterns.WEB_URL.matcher(event.text).matches()
+                        Patterns.WEB_URL.matcher(event.text).matches()
                     domain = event.text
                 }
 
@@ -94,9 +94,9 @@ class LoginScreenPresenter @Inject constructor(
                                     secret = appCreate.secret
                                     val sessionResponse = ktorfitClient.authSessionGenerate(
                                         authSessionGenerateRequestBody =
-                                            AuthSessionGenerateRequestBody(
-                                                appSecret = appCreate.secret
-                                            )
+                                        AuthSessionGenerateRequestBody(
+                                            appSecret = appCreate.secret
+                                        )
                                     )
                                     token = sessionResponse.token
                                     openUrlInChrome(
@@ -136,10 +136,10 @@ class LoginScreenPresenter @Inject constructor(
                                 suspendRunCatching {
                                     ktorfitClient.authSessionUserKey(
                                         authSessionUserKeyRequestBody =
-                                            AuthSessionUserKeyRequestBody(
-                                                appSecret = secret,
-                                                token = token
-                                            )
+                                        AuthSessionUserKeyRequestBody(
+                                            appSecret = secret,
+                                            token = token
+                                        )
                                     )
                                 }.onSuccess { authSessionResponse ->
                                     val accessToken =

--- a/feature/login/src/main/java/me/sanao1006/feature/login/LoginScreenPresenter.kt
+++ b/feature/login/src/main/java/me/sanao1006/feature/login/LoginScreenPresenter.kt
@@ -4,6 +4,7 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.util.Patterns
 import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -19,8 +20,6 @@ import de.jensklingenberg.ktorfit.Ktorfit
 import de.jensklingenberg.ktorfit.converter.FlowConverterFactory
 import de.jensklingenberg.ktorfit.converter.ResponseConverterFactory
 import io.ktor.client.HttpClient
-import java.security.MessageDigest
-import javax.inject.Inject
 import kotlinx.coroutines.launch
 import me.sanao1006.core.data.repository.createMiauthRepository
 import me.sanao1006.core.data.util.suspendRunCatching
@@ -34,6 +33,8 @@ import me.sanao1006.datastore.DataStoreRepository
 import me.sanao1006.screens.AuthStateType
 import me.sanao1006.screens.LoginScreen
 import me.snao1006.res_value.ResString
+import java.security.MessageDigest
+import javax.inject.Inject
 
 @CircuitInject(LoginScreen::class, SingletonComponent::class)
 class LoginScreenPresenter @Inject constructor(
@@ -67,8 +68,7 @@ class LoginScreenPresenter @Inject constructor(
             when (event) {
                 is LoginScreen.Event.OnTextChanged -> {
                     buttonEnabled = event.text.isNotBlank() &&
-                        event.text
-                            .matches(Regex("^https?://[a-zA-Z0-9]+(\\.[a-zA-Z0-9]+)+\$"))
+                            Patterns.WEB_URL.matcher(event.text).matches()
                     domain = event.text
                 }
 
@@ -94,9 +94,9 @@ class LoginScreenPresenter @Inject constructor(
                                     secret = appCreate.secret
                                     val sessionResponse = ktorfitClient.authSessionGenerate(
                                         authSessionGenerateRequestBody =
-                                        AuthSessionGenerateRequestBody(
-                                            appSecret = appCreate.secret
-                                        )
+                                            AuthSessionGenerateRequestBody(
+                                                appSecret = appCreate.secret
+                                            )
                                     )
                                     token = sessionResponse.token
                                     openUrlInChrome(
@@ -136,10 +136,10 @@ class LoginScreenPresenter @Inject constructor(
                                 suspendRunCatching {
                                     ktorfitClient.authSessionUserKey(
                                         authSessionUserKeyRequestBody =
-                                        AuthSessionUserKeyRequestBody(
-                                            appSecret = secret,
-                                            token = token
-                                        )
+                                            AuthSessionUserKeyRequestBody(
+                                                appSecret = secret,
+                                                token = token
+                                            )
                                     )
                                 }.onSuccess { authSessionResponse ->
                                     val accessToken =


### PR DESCRIPTION
In previous code, hyphen was not allowed in the URL at login.
Therefore, use Patterns URL validation to solve this problem.

Fixed #135