### PR TITLE
handle pager state changes in HomeScreen

### DIFF
--- a/feature/home/src/main/java/me/sanao1006/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/me/sanao1006/feature/home/HomeScreen.kt
@@ -18,8 +18,10 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.zIndex
@@ -122,6 +124,19 @@ private fun HomeScreenUiContent(
     onSocialClick: () -> Unit,
     onGlobalClick: () -> Unit
 ) {
+    LaunchedEffect(pagerState) {
+        snapshotFlow { pagerState.currentPage }.collect {
+            when (TopAppBarTimelineState.get(it)) {
+                TopAppBarTimelineState.HOME -> onHomeClick()
+
+                TopAppBarTimelineState.SOCIAL -> onSocialClick()
+
+
+                TopAppBarTimelineState.GLOBAL -> onGlobalClick()
+            }
+        }
+    }
+
     Scaffold(
         modifier = modifier
             .nestedScroll(bottomAppBarScrollBehavior.nestedScrollConnection)


### PR DESCRIPTION
In previous code, no processing was done when swiping the horizontal pager.
Therefore, when swiping the pager, the same processing as when tapping TopTab has been performed, and the timeline has been modified to switch properly.

Fixed: #138